### PR TITLE
Remove Static Constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,6 @@ PHP wrapper for the FreshBooks API. Simplifies FreshBooks API XML structure into
 
 The XML tag parameters you see on the freshbooks API page are the ones you pass to $fb->post() (as an array)
 
-Statically :
-```php
-$domain = 'your-subdomain'; // https://your-subdomain.freshbooks.com/
-$token = '1234567890'; // your api token found in your account
-Freshbooks\FreshBooksApi::init($domain, $token); 
-```
-
-Or using _construct and object instance:
-
 ```php
 $domain = 'your-subdomain'; // https://your-subdomain.freshbooks.com/
 $token = '1234567890'; // your api token found in your account
@@ -37,9 +28,6 @@ Example: list clients with an email of some@email.com
 
 ```php
 // Method names are the same as found on the freshbooks API
-// Statically
-$fb = new Freshbooks\FreshBooksApi('client.list');
-// Or 
 $fb->setMethod('client.list');
 
 // For complete list of arguments see FreshBooks docs at http://developers.freshbooks.com

--- a/src/Freshbooks/FreshBooksApi.php
+++ b/src/Freshbooks/FreshBooksApi.php
@@ -18,18 +18,16 @@ class FreshBooksApi {
     /*
      * The domain you need when making a request
      */
-    protected static $_domain = '';
     protected $domain = '';
 
     /*
      * The API token you need when making a request
      */
-    protected static $_token = '';
     protected $token = '';
 
     /*
      * The API url we're hitting. {{ DOMAIN }} will get replaced with $domain
-     * when you set FreshBooksApi::init($domain, $token)
+     * when you set `new FreshBooksApi($domain, $token)`
      */
     protected $_api_url = 'https://{{ DOMAIN }}.freshbooks.com/api/2.1/xml-in';
 
@@ -58,19 +56,6 @@ class FreshBooksApi {
      * Holds the response after our request
      */
     protected $_response = array();
-
-    /*
-     * Initialize the and store the domain/token for making requests
-     *
-     * @param string $domain The subdomain like 'yoursite'.freshbooks.com
-     * @param string $token The token found in your account settings area
-     * @return null
-     */
-    public static function init($domain, $token)
-    {
-        self::$_domain = $domain;
-        self::$_token = $token;
-    }
 
     /**
      * Initialize the and store the domain/token for making requests as init
@@ -169,7 +154,7 @@ class FreshBooksApi {
         if(!$this->domain || !$this->token)
         {
             throw new FreshBooksApiException(
-                'You need to call new FreshBooksApi($domain, $token) or FreshBooksApi::init($domain, $token) with your domain and token.'
+                'You need to call new FreshBooksApi($domain, $token) with your domain and token.'
             );
         }
 

--- a/src/sample.php
+++ b/src/sample.php
@@ -5,7 +5,6 @@ use Freshbooks\FreshBooksApi;
 // Setup the login credentials
 $domain = '';
 $token = '';
-FreshBooksApi::init($domain, $token);
 
 /**********************************************
  * Fetch all clients by a specific id

--- a/src/sample.php
+++ b/src/sample.php
@@ -10,7 +10,8 @@ FreshBooksApi::init($domain, $token);
 /**********************************************
  * Fetch all clients by a specific id
  **********************************************/
-$fb = new FreshBooksApi('client.list');
+$fb = new FreshBooksApi($domain, $token);
+$fb->setMethod('client.list');
 $fb->post(array(
     'email' => 'some@email.com'
 ));
@@ -29,7 +30,8 @@ else
 /**********************************************
  * List invoices from a specific client
  **********************************************/
-$fb = new FreshBooksApi('invoice.list');
+$fb = new FreshBooksApi($domain, $token);
+$fb->setMethod('invoice.list');
 $fb->post(array(
     'client_id' => 41
 ));
@@ -47,7 +49,8 @@ else
 /**********************************************
  * Create a recurring profile with multiple line items
  **********************************************/
-$fb = new FreshBooksApi('recurring.create');
+$fb = new FreshBooksApi($domain, $token);
+$fb->setMethod('recurring.create');
 $fb->post(array(
     'recurring' => array(
         'client_id' => 41,


### PR DESCRIPTION
When the change was made to add a proper constructor that takes the domain and token as parameters, it made a breaking change in the code, that the method was no longer passed in to the constructor.

This PR removes the `init()` method and the protected static properties `$_domain` and `$_token` as they are never used outside of the `init()` method. The PR also updated the sample.php and README to remove these references and adds use of the `setMethod()` in the README and sample.php as well.

---

If/when this PR is accepted, can we get a tagged version of this package to use in Composer instead of `dev-master`?