### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ if($fb->success()) {
  - Jordan Boesch - http://boedesign.com/
  - Jason Reading - http://jasonreading.com
  - Robert Conner - http://smartersoftware.net
+ 
+ Test on [RapidAPI](https://rapidapi.com/package/FreshbooksAPI/functions?utm_source=FreshbooksGitHub&utm_medium=button)


### PR DESCRIPTION
I've added a link in your README to Freshbooks's functions page in RapidAPI. I've done this for a few Freshbooks SDKs to help those who are reading the READMEs, understand and test the API before use.